### PR TITLE
We need this

### DIFF
--- a/media/Android.mk
+++ b/media/Android.mk
@@ -16,7 +16,7 @@
 
 ifeq ($(TARGET_SOC), u8500)
 
-media-libs := libomxil-bellagio
+media-libs := libomxil-bellagio libstelpcutils
 include $(call all-named-subdir-makefiles,$(media-libs))
 
 endif


### PR DESCRIPTION
E/BellagioCore( 6891): library /system/lib/libste_ensloader.so dlopen error: dlopen failed: could not load library "libstelpcutils.so" needed by "libste_ensloader.so"; caused by library "libstelpcutils.so" not found
